### PR TITLE
fix: 選択した通りのメニューと合計額が正しく出力されるよう修正

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'debug'
 
 DRINKS = [
   { name: 'コーヒー', price: '300' },

--- a/cafe.rb
+++ b/cafe.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'debug'
 
 DRINKS = [
   { name: 'コーヒー', price: '300' },
@@ -19,7 +20,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = (gets.to_i) - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +31,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = (DRINKS[order1][:price].to_i) + (FOODS[order2][:price].to_i)
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
# これは何か

プラクティス「カレンダーのプログラム(Ruby)」の課題提出のためのPR

# 出力結果

<img width="381" alt="スクリーンショット 2023-09-30 0 36 55" src="https://github.com/triton27/bug_cafe/assets/48582930/9311bcce-b871-4b4e-8b9e-245cc9610f88">
<img width="376" alt="スクリーンショット 2023-09-30 0 37 14" src="https://github.com/triton27/bug_cafe/assets/48582930/178b5978-3949-42e5-920f-8006dd4eaf67">